### PR TITLE
ユーザープロフィール画面の作成+alpha

### DIFF
--- a/frontend_Project/node/frontend/next-env.d.ts
+++ b/frontend_Project/node/frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/frontend_Project/node/frontend/src/components/molecules/HeaderButton.tsx
+++ b/frontend_Project/node/frontend/src/components/molecules/HeaderButton.tsx
@@ -6,6 +6,7 @@ type HeaderButtonProps = {
     variant?: string;
     onClick: ()=>void;
     icon?: ReactNode;
+    curPage: string;
 }
 
 export const HeaderButton = ({
@@ -13,10 +14,13 @@ export const HeaderButton = ({
     variant='ghost',
     onClick,
     icon,
+    curPage,
 }: HeaderButtonProps) => {
+    const cur = curPage===text;
+    const color = cur ? 'blue' : 'black';
     return (
         <Box>
-            <Button variant={variant} onClick={onClick}>
+            <Button variant={variant} onClick={onClick} color={color} isDisabled={cur}>
                 {icon? icon: null}
                 <Text fontSize='x-large' ml='5%'>{text}</Text>
             </Button>

--- a/frontend_Project/node/frontend/src/components/molecules/SearchCheckBox.tsx
+++ b/frontend_Project/node/frontend/src/components/molecules/SearchCheckBox.tsx
@@ -4,14 +4,16 @@ import React from "react";
 type SearchCheckBoxProps = {
     text: string;
     onChange: (e:React.ChangeEvent)=>void;
+    isDisabled: boolean;
 }
 
 export const SearchCheckBox = ({
     text,
     onChange,
+    isDisabled,
 }: SearchCheckBoxProps) => {
     return (
-        <Checkbox colorScheme='green' borderColor='green' onChange={onChange}>
+        <Checkbox isDisabled={isDisabled} colorScheme='green' borderColor='green' onChange={onChange}>
             <Text>{text}</Text>
         </Checkbox>
     );

--- a/frontend_Project/node/frontend/src/components/molecules/UserButton.tsx
+++ b/frontend_Project/node/frontend/src/components/molecules/UserButton.tsx
@@ -1,25 +1,52 @@
-import { Text, Button, Box } from "@chakra-ui/react";
-import React, { ReactNode, useState } from "react";
+import { Text, Button, Box, HStack, Menu, MenuButton, MenuList, MenuItem } from "@chakra-ui/react";
+import { useAuthUserContext } from "../../providers/AuthUser";
+import React from "react";
 import { User } from "../../types/User";
-import { AccountCircle } from "@mui/icons-material";
+import { AccountCircle, KeyboardArrowDownOutlined, Logout } from "@mui/icons-material";
+import { useRouter } from "next/router";
+import { TOP_PAGE } from "../../consts/PAGE";
 
 type UserButtonProps = {
     user: User | null;
     variant?: string;
     onClick: ()=>void;
+    curPage: string;
 }
 
 export const UserButton = ({
     user,
     variant='ghost',
     onClick,
+    curPage,
 }: UserButtonProps) => {
+    const {signout} = useAuthUserContext();
+    const router = useRouter();
+    const cur = curPage==='プロフィール';
+    const color = cur ? 'blue' : 'black';
+    const logout = () => {
+        signout(()=>{
+            router.push(TOP_PAGE);
+        });
+    };
     return (
         <Box>
-            <Button variant={variant} onClick={onClick}>
-                <AccountCircle/>
-                {user ? <Text fontSize='x-large'>{user.name}</Text> : null}
-            </Button>
+            <Menu>
+                <MenuButton variant={variant} as={Button} rightIcon={<KeyboardArrowDownOutlined/>}>
+                    <HStack color={color}>
+                        <AccountCircle/>
+                        {user ? <Text fontSize='x-large'>{user.name}</Text> : null}
+                    </HStack>
+                </MenuButton>
+                <MenuList>
+                    <MenuItem onClick={onClick} isDisabled={cur}><Text>プロフィール</Text></MenuItem>
+                    <MenuItem onClick={logout}>
+                        <HStack>
+                            <Logout/>
+                            <Text>ログアウト</Text>
+                        </HStack>
+                    </MenuItem>
+                </MenuList>
+            </Menu>
         </Box>
     );
 };

--- a/frontend_Project/node/frontend/src/components/orgnism/BookCard.tsx
+++ b/frontend_Project/node/frontend/src/components/orgnism/BookCard.tsx
@@ -59,11 +59,11 @@ export const BookCard = ({
             <Box minW={width} maxW={width} height={height} onClick={onOpen}>
                 <Card w='100%' h='100%' variant='filled'>
                     <CardBody h='80%' p={1}>
-                        <Flex w='100%' h='90%' justify='center'>
+                        <Flex w='100%' h='85%' justify='center'>
                             <Image objectFit='cover' src={image as string} />
                         </Flex>
-                        <Flex h='10%' justify='left' overflow='hidden'>
-                            <Text w='100%' fontSize='x-small'>{book.title}</Text>
+                        <Flex h='15%' justify='left' overflow='hidden'>
+                            <Text isTruncated w='100%' fontSize='small'>{book.title}</Text>
                         </Flex>
                     </CardBody>
                     <Divider/>

--- a/frontend_Project/node/frontend/src/components/orgnism/Header.tsx
+++ b/frontend_Project/node/frontend/src/components/orgnism/Header.tsx
@@ -9,7 +9,7 @@ import UserButton from "../molecules/UserButton";
 import { useAuthUserContext } from "../../providers/AuthUser";
 
 type HeaderProps = {
-    curPage: String;
+    curPage: string;
 };
 
 export const Header = ({
@@ -21,13 +21,13 @@ export const Header = ({
         <HStack w="100%" h="10vh" bgColor='rgba(200,200,200,0.8)' px='10%'>
             <CurTime/>
             <Spacer/>
-            <HeaderButton text='本の追加' onClick={()=>{router.push(ADD_BOOK);}} icon={<LibraryAdd/>} />
+            <HeaderButton curPage={curPage} text='本の追加' onClick={()=>{router.push(ADD_BOOK);}} icon={<LibraryAdd/>} />
             <Spacer/>
-            <HeaderButton text='本棚' onClick={()=>{router.push(BOOKS);}} icon={<LibraryBooks/>} />
+            <HeaderButton curPage={curPage} text='本棚' onClick={()=>{router.push(BOOKS);}} icon={<LibraryBooks/>} />
             <Spacer/>
-            <HeaderButton text='本を探す' onClick={()=>{router.push(RECOMMEND_BOOK)}} icon={<Recommend/>} />
+            <HeaderButton curPage={curPage} text='本を探す' onClick={()=>{router.push(RECOMMEND_BOOK)}} icon={<Recommend/>} />
             <Spacer/>
-            <UserButton user={user} onClick={()=>{router.push(USER_PROFILE);}} />
+            <UserButton curPage={curPage} user={user} onClick={()=>{router.push(USER_PROFILE);}} />
         </HStack>
     );
 };

--- a/frontend_Project/node/frontend/src/components/orgnism/MyBookCard.tsx
+++ b/frontend_Project/node/frontend/src/components/orgnism/MyBookCard.tsx
@@ -68,11 +68,11 @@ export const MyBookCard = ({
             <Box minW={width} maxW={width} height={height} onClick={onOpen}>
                 <Card w='100%' h='100%' variant='filled'>
                     <CardBody h='80%' p={1}>
-                        <Flex w='100%' h='90%' justify='center'>
+                        <Flex w='100%' h='85%' justify='center'>
                             <Image objectFit='cover' src={image as string} />
                         </Flex>
-                        <Flex h='10%' justify='left' overflow='hidden'>
-                            <Text w='100%' fontSize='x-small'>{book.title}</Text>
+                        <Flex h='15%' justify='left' overflow='hidden'>
+                            <Text isTruncated w='100%' fontSize='small'>{book.title}</Text>
                         </Flex>
                     </CardBody>
                     <Divider/>

--- a/frontend_Project/node/frontend/src/components/orgnism/SearchArea.tsx
+++ b/frontend_Project/node/frontend/src/components/orgnism/SearchArea.tsx
@@ -14,6 +14,7 @@ type SearchAreaProps = {
     setIsOnlyFavorite?: any;
     setIsReadingState?: any;
     setIsCheckedCategory: any;
+    isDisabled: boolean;
 };
 
 export const SearchArea = ({
@@ -25,6 +26,7 @@ export const SearchArea = ({
     setIsOnlyFavorite,
     setIsReadingState,
     setIsCheckedCategory,
+    isDisabled,
 }: SearchAreaProps) => {
     const handleChangeIsReadingState = (e: any, stateNum: number) => {
         setIsReadingState((prev: boolean[]) => prev.map((value, idx) => {
@@ -39,9 +41,9 @@ export const SearchArea = ({
     return (
         <VStack h='100%' width={width} maxW={width} spacing='5%' p='8px' bg='rgba(50,50,200,0.2)' borderColor='black' borderWidth='3px'>
             <HStack h='10%' w='100%' spacing={5} align='center' p='8px'>
-                <Input bgColor='white' placeholder='フリーワード' value={keyword} onChange={(e)=>{setKeyword(e.target.value)}} />
+                <Input isDisabled={isDisabled} bgColor='white' placeholder='フリーワード' value={keyword} onChange={(e)=>{setKeyword(e.target.value)}} />
                 <Tooltip label='検索'>
-                    <Button colorScheme="blue" onClick={onClick}>
+                    <Button isDisabled={isDisabled} colorScheme="blue" onClick={onClick}>
                         <Search/>
                     </Button>
                 </Tooltip>
@@ -53,10 +55,10 @@ export const SearchArea = ({
                     </Flex>
                     <Divider borderColor='black' />
                     <VStack w='100%' alignItems='left' overflow='auto'>
-                        <SearchCheckBox text='お気に入り' onChange={(e: any)=>{setIsOnlyFavorite(e.target.checked)}} />
+                        <SearchCheckBox isDisabled={isDisabled} text='お気に入り' onChange={(e: any)=>{setIsOnlyFavorite(e.target.checked)}} />
                         {STATES.state.map((state, idx) => {
                             return (
-                                <SearchCheckBox text={state} onChange={(e)=>{handleChangeIsReadingState(e, idx)}}/>
+                                <SearchCheckBox isDisabled={isDisabled} text={state} onChange={(e)=>{handleChangeIsReadingState(e, idx)}}/>
                             );
                         })}
                     </VStack>
@@ -70,7 +72,7 @@ export const SearchArea = ({
                 <VStack w='100%' alignItems='left' overflow='auto'>
                     {CATEGORIES.categories.map((category, idx) => {
                         return (
-                            <SearchCheckBox text={category} onChange={(e)=>{handleChangeIsCheckedCategory(e, idx)}}/>
+                            <SearchCheckBox isDisabled={isDisabled} text={category} onChange={(e)=>{handleChangeIsCheckedCategory(e, idx)}}/>
                         );
                     })}
                 </VStack>

--- a/frontend_Project/node/frontend/src/components/orgnism/SimpleCard.tsx
+++ b/frontend_Project/node/frontend/src/components/orgnism/SimpleCard.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Box, Card, CardBody, CardHeader, Divider, Flex, HStack, Text, VStack } from "@chakra-ui/react";
+
+type SimpleCardProps = {
+    label: string;
+    value: string;
+    size: 'large'|'normal';
+};
+
+export const SimpleCard = ({
+    label,
+    value,
+    size,
+}: SimpleCardProps) => {
+    const width = size==='large' ? '300px' : '250px';
+    const height = size==='large' ? '150px' : '125px';
+    const labelFontSize = size==='large' ? 'larger' : 'large';
+    const valueFontSize = size==='large' ? 'xxx-large' : 'xx-large';
+    return (
+        <Box minW={width} maxW={width} minH={height} maxH={height}>
+            <Card w='100%' h='100%'>
+                <CardHeader py={0}>
+                    <Flex justify='left'>
+                        <Text isTruncated fontSize={labelFontSize}>{label}</Text>
+                    </Flex>
+                </CardHeader>
+                <Divider/>
+                <CardBody>
+                    <Flex justify='right'>
+                        <Text fontSize={valueFontSize} fontWeight='bold'>{value}</Text>
+                    </Flex>
+                </CardBody>
+            </Card>
+        </Box>
+    );
+};
+
+export default SimpleCard;

--- a/frontend_Project/node/frontend/src/components/template/AddBook.tsx
+++ b/frontend_Project/node/frontend/src/components/template/AddBook.tsx
@@ -12,7 +12,7 @@ const AddBook = () => {
 export const AddBookTemplate = () => {
     return (
         <VStack bgImage={commonBG} bgSize='cover' bgRepeat='no-repeat' h='100vh' overflow='hidden'>
-            <Header curPage='本棚'/>
+            <Header curPage='本の追加'/>
             <Flex w='100%' h='90vh' alignItems='center' justify='center'>
                 <Box alignItems='center' w='90%' maxW='90%' h='90%' bgColor='rgba(255,255,255,0.5)' p='8px' overflow='auto'>
                     <AddBook/>

--- a/frontend_Project/node/frontend/src/components/template/Books.tsx
+++ b/frontend_Project/node/frontend/src/components/template/Books.tsx
@@ -13,6 +13,7 @@ import { searchBooks } from "../../functions/searchBooks";
 const Books = () => {
     const {user} = useAuthUserContext();
     const [bookList, setBookList] = useState<MyBook[]>([]);
+    const [isDisabled, setIsDisabled] = useState<boolean>(false);
     const [keyword, setKeyword] = useState<string>('');
     const [isOnlyFavorite, setIsOnlyFavorite] = useState<boolean>(false);
     const [isReadingState, setIsReaingState] = useState<boolean[]>([false,false,false]);
@@ -23,13 +24,16 @@ const Books = () => {
         if(!user) return ;
         const res = await getBooks(user.id);
         setBookList(res);
+        setIsDisabled(false);
     };
     const getBooksBySearchOptions = async () => {
         if(!user) return ;
         const res = await searchBooks(user.id, isOnlyFavorite, isReadingState, isCheckedCategory);
         setBookList(res);
+        setIsDisabled(false);
     };
     useEffect(() => {
+        setIsDisabled(true);
         if(isFirstTime.current){
             getBooksByUserId();
             isFirstTime.current = false;
@@ -47,6 +51,7 @@ const Books = () => {
                 setIsOnlyFavorite={setIsOnlyFavorite}
                 setIsReadingState={setIsReaingState}
                 setIsCheckedCategory={setIsCheckedCategory}
+                isDisabled={isDisabled}
             />
             <Box width='75%' maxH='100%' overflow='auto'>
                 <Grid templateColumns='repeat(5, 1fr)' gap={5}>

--- a/frontend_Project/node/frontend/src/components/template/RecommendBook.tsx
+++ b/frontend_Project/node/frontend/src/components/template/RecommendBook.tsx
@@ -69,7 +69,7 @@ const RecommendBook = () => {
 export const RecommendBookTemplate = () => {
     return (
         <VStack bgImage={commonBG} bgSize='cover' bgRepeat='no-repeat' h='100vh' overflow='hidden'>
-            <Header curPage='本を追加' />
+            <Header curPage='本を探す' />
             <Flex w='100%' h='90vh' alignItems='center' justify='center'>
                 <Box alignItems='center' w='90%' maxW='90%' h='90%' bgColor='rgba(255,255,255,0.5)' p='8px'>
                     <RecommendBook/>

--- a/frontend_Project/node/frontend/src/components/template/RecommendBook.tsx
+++ b/frontend_Project/node/frontend/src/components/template/RecommendBook.tsx
@@ -12,6 +12,7 @@ import BookCard from "../orgnism/BookCard";
 
 const RecommendBook = () => {
     const {user} = useAuthUserContext();
+    const [isDisabled, setIsDisabled] = useState<boolean>(false);
     const [keyword, setKeyword] = useState<string>('');
     const [isCheckedCategory, setIsCheckedCategory] = useState<boolean[]>([...Array(CATEGORIES_NUM)].map(()=>false));
     const [bookListByCategory, setBookListByCategory] = useState<{
@@ -23,8 +24,10 @@ const RecommendBook = () => {
         if(!user) return;
         const res = await suggestBook(user.id, isCheckedCategory);
         setBookListByCategory(res);
+        setIsDisabled(false);
     };
     useEffect(()=>{
+        setIsDisabled(true);
         getSuggestBooks();
     },[isCheckedCategory]);
     return(
@@ -36,6 +39,7 @@ const RecommendBook = () => {
                 onClick={()=>{}}
                 showStateOption={false}
                 setIsCheckedCategory={setIsCheckedCategory}
+                isDisabled={isDisabled}
             />
             <Box width='75%' h='100%' overflowY='auto'>
                 <VStack>

--- a/frontend_Project/node/frontend/src/components/template/UserProfile.tsx
+++ b/frontend_Project/node/frontend/src/components/template/UserProfile.tsx
@@ -1,22 +1,52 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import { useAuthUserContext } from "../../providers/AuthUser";
-import { Box, Flex, HStack, Text, VStack } from "@chakra-ui/react";
+import { Box, Button, Flex, Grid, HStack, Text, Tooltip, VStack } from "@chakra-ui/react";
 import { Header } from "../orgnism/Header";
 import { commonBG } from "../../consts/IMAGE";
+import { SimpleCard } from './../orgnism/SimpleCard';
+import { STATES } from "../../consts/States";
+import { CATEGORIES } from "../../consts/Categories";
+import { Refresh } from "@mui/icons-material";
 
 const UserProfile = () => {
-    const { user } = useAuthUserContext();
+    const { user, fetchUser } = useAuthUserContext();
     return (
-        <VStack>
-            <HStack>
-                <Text>ユーザー名</Text>
-                <Text>{user?.name}</Text>
-            </HStack>
-            <HStack>
-                <Text>ランク</Text>
-                <Text>{user?.role}</Text>
-            </HStack>
-        </VStack>
+        <>
+            { (!!user) ?
+                <VStack w='100%' maxH='100%' overflow='auto'>
+                    <HStack>
+                        <Flex h='10%' px={5} bg='rgba(50,50,200,0.5)'>
+                            <Text fontSize='xx-large' fontWeight='bold'>
+                                {(user?.name||'') + '　のダッシュボード'}
+                            </Text>
+                        </Flex>
+                        <Tooltip label='更新'>
+                            <Button variant='ghost' onClick={fetchUser}>
+                                    <Refresh/>
+                            </Button>
+                        </Tooltip>
+                    </HStack>
+                    <VStack maxH='90%' p={2} bg='rgba(200,100,0,0.5)' overflow='auto'>
+                        <HStack>
+                            {user.stateCount.map((value, idx) => {
+                                const label = STATES.state[idx];
+                                return (
+                                    <SimpleCard label={label} value={String(value)} size='large'/>
+                                );
+                            })}
+                        </HStack>
+                        <Grid templateColumns='repeat(4, 1fr)' gap={2}>
+                            {user.categoryCount.map((value, idx) => {
+                                const label = CATEGORIES.categories[idx];
+                                return (
+                                    <SimpleCard label={label} value={String(value)} size='normal'/>
+                                );
+                            })}
+                        </Grid>
+                    </VStack>
+                </VStack>
+            : null}
+        </>
     );
 }
 
@@ -25,7 +55,7 @@ export const UserProfileTemplate = () => {
         <VStack bgImage={commonBG} bgSize='cover' bgRepeat='no-repeat' h='100vh' overflow='hidden'>
             <Header curPage='プロフィール'/>
             <Flex w='100%' h='90vh' alignItems='center' justify='center'>
-                <Box alignItems='center' w='90%' maxW='90%' h='90%' bgColor='rgba(255,255,255,0.5)' p='8px' overflow='auto'>
+                <Box alignItems='center' w='90%' maxW='90%' h='90%' bgColor='rgba(255,255,255,0.5)' p='8px'>
                     <UserProfile/>
                 </Box>
             </Flex>

--- a/frontend_Project/node/frontend/src/components/template/UserProfile.tsx
+++ b/frontend_Project/node/frontend/src/components/template/UserProfile.tsx
@@ -23,7 +23,7 @@ const UserProfile = () => {
 export const UserProfileTemplate = () => {
     return (
         <VStack bgImage={commonBG} bgSize='cover' bgRepeat='no-repeat' h='100vh' overflow='hidden'>
-            <Header curPage='本棚'/>
+            <Header curPage='プロフィール'/>
             <Flex w='100%' h='90vh' alignItems='center' justify='center'>
                 <Box alignItems='center' w='90%' maxW='90%' h='90%' bgColor='rgba(255,255,255,0.5)' p='8px' overflow='auto'>
                     <UserProfile/>

--- a/frontend_Project/node/frontend/src/providers/AuthUser.tsx
+++ b/frontend_Project/node/frontend/src/providers/AuthUser.tsx
@@ -9,6 +9,7 @@ export type AuthUserContextType = {
     token: String | null;
     signin: (user:User, token:String | null, callback:() => void) => void;
     signout: (callback:() => void) => void;
+	fetchUser: ()=>void;
 }
 
 const AuthUserContext = React.createContext<AuthUserContextType>({} as AuthUserContextType);
@@ -18,8 +19,8 @@ export const useAuthUserContext = ():AuthUserContextType => {
 }
 
 type Props = {
-    children: React.ReactNode
-  }
+	children: React.ReactNode
+}
 
 export const AuthUserProvider = (props: Props) => {
     const [isUserLoading, setIsUserLoading] = useState(true);
@@ -33,15 +34,15 @@ export const AuthUserProvider = (props: Props) => {
         if(!!savedToken){
             setIsLogin(true);
             const getUserById = async () => {
-              const res = await getUser(Number(savedUserId));
-              setUser(res);
-              setIsUserLoading(false);
+				const res = await getUser(Number(savedUserId));
+				setUser(res);
+				setIsUserLoading(false);
             };
             getUserById();
             setToken(savedToken);
         }else{
-			setIsUserLoading(false);
-		}
+          	setIsUserLoading(false);
+        }
     },[]);
 
     const signin = (newUser: User,token: String | null, callback: () => void) => {
@@ -62,11 +63,21 @@ export const AuthUserProvider = (props: Props) => {
       callback();
     }
 
+    const fetchUser = () => {
+        const savedUserId = sessionStorage.getItem('userId');
+		setIsUserLoading(true);
+		const getUserById = async () => {
+			const res = await getUser(Number(savedUserId));
+			setUser(res);
+			setIsUserLoading(false);
+		};
+		getUserById();
+	};
 
-    const value:AuthUserContextType = {isUserLoading, isLogin, user, token, signin, signout };
+    const value:AuthUserContextType = {isUserLoading, isLogin, user, token, signin, signout, fetchUser };
     return (
-      <AuthUserContext.Provider value={value}>
-        {props.children}
-      </AuthUserContext.Provider>
+    	<AuthUserContext.Provider value={value}>
+			{props.children}
+      	</AuthUserContext.Provider>
     );
 }


### PR DESCRIPTION
## やったこと
- ユーザープロフィール画面を作成する
- 今いるページをヘッダーから分かるようにし、ボタンを非活性化する
- ユーザー名ボタンを、メニューボタンに変更
- 検索処理中に検索エリアを非活性化
- 本のCardのタイトルを大きくする

## 確認してほしいこと
- ユーザープロフィールのデザインについて
例えば、スクロールはカテゴリの部分だけにして読書状況は固定されていてほしい、など。