### PR TITLE
画像をブラウザで保存して、APIを叩く回数を減らす

### DIFF
--- a/frontend_Project/node/frontend/next-env.d.ts
+++ b/frontend_Project/node/frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/frontend_Project/node/frontend/src/components/template/Books.tsx
+++ b/frontend_Project/node/frontend/src/components/template/Books.tsx
@@ -9,9 +9,11 @@ import { CATEGORIES_NUM } from "../../consts/Categories";
 import { MyBook } from "../../types/MyBook";
 import MyBookCard from "../orgnism/MyBookCard";
 import { searchBooks } from "../../functions/searchBooks";
+import { useCacheImageContext } from "../../providers/CacheImage";
 
 const Books = () => {
     const {user} = useAuthUserContext();
+    const {getImageWithCache} = useCacheImageContext();
     const [bookList, setBookList] = useState<MyBook[]>([]);
     const [keyword, setKeyword] = useState<string>('');
     const [isOnlyFavorite, setIsOnlyFavorite] = useState<boolean>(false);
@@ -21,12 +23,12 @@ const Books = () => {
 
     const getBooksByUserId = async () => {
         if(!user) return ;
-        const res = await getBooks(user.id);
+        const res = await getBooks(user.id, getImageWithCache);
         setBookList(res);
     };
     const getBooksBySearchOptions = async () => {
         if(!user) return ;
-        const res = await searchBooks(user.id, isOnlyFavorite, isReadingState, isCheckedCategory);
+        const res = await searchBooks(user.id, isOnlyFavorite, isReadingState, isCheckedCategory, getImageWithCache);
         setBookList(res);
     };
     useEffect(() => {

--- a/frontend_Project/node/frontend/src/components/template/RecommendBook.tsx
+++ b/frontend_Project/node/frontend/src/components/template/RecommendBook.tsx
@@ -6,12 +6,13 @@ import SearchArea from "../orgnism/SearchArea";
 import { CATEGORIES, CATEGORIES_NUM } from "../../consts/Categories";
 import { Book } from "../../types/Book";
 import { suggestBook } from "../../functions/suggestBoook";
-import { getBooks } from "../../functions/getBooks";
 import { useAuthUserContext } from "../../providers/AuthUser";
 import BookCard from "../orgnism/BookCard";
+import { useCacheImageContext } from "../../providers/CacheImage";
 
 const RecommendBook = () => {
     const {user} = useAuthUserContext();
+    const {getImageWithCache} = useCacheImageContext();
     const [keyword, setKeyword] = useState<string>('');
     const [isCheckedCategory, setIsCheckedCategory] = useState<boolean[]>([...Array(CATEGORIES_NUM)].map(()=>false));
     const [bookListByCategory, setBookListByCategory] = useState<{
@@ -21,7 +22,7 @@ const RecommendBook = () => {
 
     const getSuggestBooks = async () => {
         if(!user) return;
-        const res = await suggestBook(user.id, isCheckedCategory);
+        const res = await suggestBook(user.id, isCheckedCategory, getImageWithCache);
         setBookListByCategory(res);
     };
     useEffect(()=>{

--- a/frontend_Project/node/frontend/src/functions/getBookImage.ts
+++ b/frontend_Project/node/frontend/src/functions/getBookImage.ts
@@ -13,7 +13,7 @@ export async function getBookImage(ISBN: String) {
         apiIsSuccess = false;
     });
     if(apiIsSuccess){
-        return [URL.createObjectURL(res.data)];
+        return URL.createObjectURL(res.data);
     }else{
         return imageNotFound;
     }

--- a/frontend_Project/node/frontend/src/functions/getBooks.ts
+++ b/frontend_Project/node/frontend/src/functions/getBooks.ts
@@ -3,9 +3,8 @@ import { POST_BOOKS } from "../consts/API";
 import { MyBook } from "../types/MyBook";
 import { CATEGORIES } from "../consts/Categories";
 import { STATES } from "../consts/States";
-import { getBookImage } from "./getBookImage";
 
-export async function getBooks(userId: number): Promise<MyBook[]>{
+export async function getBooks(userId: number, getBookImageFunc: any): Promise<MyBook[]>{
     let apiIsSuccess = true ;
     const res: any = await axios.post(POST_BOOKS, {
         user_id: userId,
@@ -17,7 +16,7 @@ export async function getBooks(userId: number): Promise<MyBook[]>{
     if( apiIsSuccess && res.data['is_success']) apiIsSuccess = false;
     if(apiIsSuccess){
         return await Promise.all(res.data.map(async (book: any) => {
-            const image = await getBookImage(book['ISBN']);
+            const image = await getBookImageFunc(book['ISBN']);
             const res: MyBook =  {
                 userId: userId,
                 bookId: book['_book_id'],

--- a/frontend_Project/node/frontend/src/functions/searchBooks.ts
+++ b/frontend_Project/node/frontend/src/functions/searchBooks.ts
@@ -3,13 +3,13 @@ import { POST_BOOKS } from "../consts/API";
 import { MyBook } from "../types/MyBook";
 import { CATEGORIES } from "../consts/Categories";
 import { STATES } from "../consts/States";
-import { getBookImage } from "./getBookImage";
 
 export async function searchBooks(
         userId: number,
         isFavorite: boolean,
         isReadingState: boolean[],
-        isCheckedCategories: boolean[]
+        isCheckedCategories: boolean[],
+        getBookImageFunc: any,
     ): Promise<MyBook[]>{
     let apiIsSuccess = true ;
     const favorite: string = isFavorite ? '1' : '0 1';
@@ -43,7 +43,7 @@ export async function searchBooks(
     if( apiIsSuccess && res.data['is_success']) apiIsSuccess = false;
     if(apiIsSuccess){
         return await Promise.all(res.data.map(async (book: any) => {
-            const image = await getBookImage(book['ISBN']);
+            const image = await getBookImageFunc(book['ISBN']);
             const res: MyBook =  {
                 userId: userId,
                 bookId: book['_book_id'],

--- a/frontend_Project/node/frontend/src/functions/suggestBoook.ts
+++ b/frontend_Project/node/frontend/src/functions/suggestBoook.ts
@@ -1,10 +1,9 @@
 import axios from "axios";
 import { POST_BOOK_SUGGEST } from "../consts/API";
-import { getBookImage } from "./getBookImage";
 import { Book } from "../types/Book";
 import { CATEGORIES } from "../consts/Categories";
 
-export async function suggestBook(userId: Number, isCheckedCategories: boolean[]): Promise<{
+export async function suggestBook(userId: Number, isCheckedCategories: boolean[], getBookImageFunc: any): Promise<{
     category: string,
     books: Book[],
 }[]>{
@@ -30,7 +29,7 @@ export async function suggestBook(userId: Number, isCheckedCategories: boolean[]
         const keys = Object.keys(res.data);
         const response = keys.map(async (category: any) => {
             const books = await Promise.all(res.data[category].map( async (book: any) => {
-                const image = await getBookImage(book['ISBN']);
+                const image = await getBookImageFunc(book['ISBN']);
                 const res: Book =  {
                     id: book['id'],
                     ISBN: book['ISBN'],

--- a/frontend_Project/node/frontend/src/providers/AuthUser.tsx
+++ b/frontend_Project/node/frontend/src/providers/AuthUser.tsx
@@ -19,7 +19,7 @@ export const useAuthUserContext = ():AuthUserContextType => {
 
 type Props = {
     children: React.ReactNode
-  }
+}
 
 export const AuthUserProvider = (props: Props) => {
     const [isUserLoading, setIsUserLoading] = useState(true);
@@ -45,21 +45,21 @@ export const AuthUserProvider = (props: Props) => {
     },[]);
 
     const signin = (newUser: User,token: String | null, callback: () => void) => {
-      setIsLogin(true);
-      setUser(newUser);
-      setToken(token);
-      sessionStorage.setItem('userId', String(newUser.id));
-      sessionStorage.setItem('token', token?.toString()||'');
-      callback();
+		setIsLogin(true);
+		setUser(newUser);
+		setToken(token);
+		sessionStorage.setItem('userId', String(newUser.id));
+		sessionStorage.setItem('token', token?.toString()||'');
+		callback();
     }
 
     const signout = (callback: () => void) => {
-      setIsLogin(false);
-      setUser(null);
-      setToken(null);
-      sessionStorage.removeItem('userId');
-      sessionStorage.removeItem('token');
-      callback();
+		setIsLogin(false);
+		setUser(null);
+		setToken(null);
+		sessionStorage.removeItem('userId');
+		sessionStorage.removeItem('token');
+		callback();
     }
 
 

--- a/frontend_Project/node/frontend/src/providers/AuthUser.tsx
+++ b/frontend_Project/node/frontend/src/providers/AuthUser.tsx
@@ -65,8 +65,8 @@ export const AuthUserProvider = (props: Props) => {
 
     const value:AuthUserContextType = {isUserLoading, isLogin, user, token, signin, signout };
     return (
-      <AuthUserContext.Provider value={value}>
-        {props.children}
-      </AuthUserContext.Provider>
+    	<AuthUserContext.Provider value={value}>
+			{props.children}
+    	</AuthUserContext.Provider>
     );
 }

--- a/frontend_Project/node/frontend/src/providers/CacheImage.tsx
+++ b/frontend_Project/node/frontend/src/providers/CacheImage.tsx
@@ -1,0 +1,31 @@
+import React, { createContext, ReactNode, useContext, useEffect, useState } from "react";
+
+export type CacheImageContextType = {
+    getImage: (ISBN: number) => string;
+};
+
+const CacheImageContext = createContext<CacheImageContextType>({} as CacheImageContextType);
+
+export const useCacheImageContext = (): CacheImageContextType => {
+    return useContext<CacheImageContextType>(CacheImageContext);
+};
+
+type Props = {
+    children: ReactNode;
+};
+
+export const CacheImageProvider = (props: Props) => {
+    const [imageList, setImageList] = useState<{
+        ISBN: string;
+        image: string;
+    }[]>([]);
+
+    const getImageWithCache = async (ISBN: string) => {
+        const cache = imageList.filter(value=>value.ISBN===ISBN);
+        if(cache.length>0){
+            return cache[0].image;
+        }else{
+            
+        }
+    };
+}

--- a/frontend_Project/node/frontend/src/providers/CacheImage.tsx
+++ b/frontend_Project/node/frontend/src/providers/CacheImage.tsx
@@ -1,7 +1,8 @@
 import React, { createContext, ReactNode, useContext, useEffect, useState } from "react";
+import { getBookImage } from '../functions/getBookImage'
 
 export type CacheImageContextType = {
-    getImage: (ISBN: number) => string;
+    getImageWithCache: any;
 };
 
 const CacheImageContext = createContext<CacheImageContextType>({} as CacheImageContextType);
@@ -25,7 +26,21 @@ export const CacheImageProvider = (props: Props) => {
         if(cache.length>0){
             return cache[0].image;
         }else{
-            
+            const res = await getBookImage(ISBN);
+            setImageList((prev) => {
+                return [...prev, {
+                    ISBN: ISBN,
+                    image: res,
+                }]
+            });
+            return res;
         }
     };
+
+    const value: CacheImageContextType = { getImageWithCache };
+    return (
+        <CacheImageContext.Provider value={value}>
+            {props.children}
+        </CacheImageContext.Provider>
+    );
 }

--- a/frontend_Project/node/frontend/src/providers/Providers.tsx
+++ b/frontend_Project/node/frontend/src/providers/Providers.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { AuthUserProvider } from "./AuthUser";
 import { ChakraProvider } from '@chakra-ui/react'
+import { CacheImageProvider } from './CacheImage';
 
 type Props = {
     children: React.ReactNode
@@ -10,7 +11,9 @@ export const Provider = (props: Props) => {
     return (
         <ChakraProvider>
             <AuthUserProvider>
-                {props.children}
+                <CacheImageProvider>
+                    {props.children}
+                </CacheImageProvider>
             </AuthUserProvider>
         </ChakraProvider>
     );


### PR DESCRIPTION
Closes #42
## やったこと
- ブラウザでAPIを通じて取得した書影をISBNごとに保存
- 次にそのISBNの書影を取得するときはAPIを叩かずに保存済みの画像を返す

## 備考
- localStorageやsessionStorageは使っていないので、reloadしたらまたAPIで取得するようになります